### PR TITLE
'inherit' rather than 'pipe' stdio streams

### DIFF
--- a/run.js
+++ b/run.js
@@ -77,6 +77,7 @@ process.stdin.setEncoding('utf8')
 ;function restart() {
   // kill if running
   if (child) {
+    child.removeListener('exit', process.exit)
     if (signal) {
       child.kill(signal)
     } else {


### PR DESCRIPTION
This commit is intended to be a report and a suggestion, I'm not versed about this utility neither about your plans on improving it.

I've found useful to run the child giving it direct access to parent's stdio streams (through 'inherit') rather than piping them.

I was developing an interactive command line utility that makes use of `process.stdin.setRawMode` so I needed access to the tty stream in the child.

With this little change `runjs` runs perfectly as expected. My cli thinks it's executed directly on a terminal, and each time a file is modified the cli is restarted.

With the bind to 'exit' event, when the cli process finishes the runjs process finishes too, so there's no need of killing it manually with `Ctrl^C`.

Congratulations for this tool and its clean code, a quick read allowed me to know where I had to type.

Cheers
L.
