### PR TITLE
prevent run from forcing node 20,22 dep requirement of minimatch v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=v0.9.0"
   },
   "dependencies": {
-    "minimatch": "*"
+    "minimatch": "^9.0.0"
   },
   "devDependencies": {},
   "homepage": "https://github.com/dtrejo/run.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=v0.9.0"
   },
   "dependencies": {
-    "minimatch": "^9.0.0"
+    "minimatch": "^9.0.5"
   },
   "devDependencies": {},
   "homepage": "https://github.com/dtrejo/run.js",


### PR DESCRIPTION
Resolves a issues where run.js force upgrades minimatch when regenerating a lock file and forcing node >=20 due to minimatch dep change.

## Issues
- Minimatch v10 now requires nodejs >=20. 
- Run always pulls in latest minimatch regardless of architecture / nodejs version

## Fixes
- Forces run.js to version 9.x.x

## Notes
- Additional updates can point to higher versions of minimatch, but then run will need to target >=20 for nodejs

## Alternatives
Make run have minimatch as a required peer-dependency. Most modern package managers will throw an error if the user does not opt to install minimatch. Still not ideal if minimatch is directly use by this package, so not making a PR for this.