### PR TITLE
Bugfix gitignore negated patterns

### DIFF
--- a/run.js
+++ b/run.js
@@ -100,6 +100,23 @@ process.stdin.setEncoding('utf8')
   }
 }
 
+
+/**
+ * Checks if a path matches the .gitignore rules
+ *
+ * @param path {String}
+ * @return Boolean
+ */
+;function checkIgnore(path) {
+  for (var i = 0, pattern; pattern = ignoreFiles[i]; i++) {
+    if (minimatch(path, pattern)) {
+      return true
+    }
+  }
+  return false
+}
+
+
 /**
 * Parses a folder recursively and returns a list of files
 *
@@ -123,11 +140,9 @@ process.stdin.setEncoding('utf8')
     // recur if directory
     } else {
       // don't watch folders matched by .gitignore regexes
-      for (var i = 0, pattern; pattern = ignoreFiles[i]; i++) {
-        if (minimatch(file, pattern)) {
-          console.log('Found & ignored', './' + pathname, '; is listed in .gitignore')
-          return
-        }
+      if (checkIgnore(file)) {
+        console.log('Found & ignored folder', './' + pathname, '; is listed in .gitignore')
+        return
       }
       fileList = fileList.concat(parseFolder(pathname))
     }
@@ -155,16 +170,14 @@ process.stdin.setEncoding('utf8')
     // don't watch things with ignored extensions
     var ext = path.extname(file)
     if (ignoreExtensions.indexOf(ext) !== -1) {
-      console.log('Found & ignored', './' + file, '; has ignored extension')
+      console.log('Found & ignored file', './' + file, '; has ignored extension')
       return
     }
 
     // don't watch files matched by .gitignore regexes
-    for (var i = 0, pattern; pattern = ignoreFiles[i]; i++) {
-      if (minimatch(file, pattern)) {
-        console.log('Found & ignored', './' + file, '; is listed in .gitignore')
-        return
-      }
+    if (checkIgnore(file)) {
+      console.log('Found & ignored file', './' + file, '; is listed in .gitignore')
+      return
     }
 
     // if any file changes, run the callback

--- a/run.js
+++ b/run.js
@@ -108,12 +108,21 @@ process.stdin.setEncoding('utf8')
  * @return Boolean
  */
 ;function checkIgnore(path) {
+  ignore = false
   for (var i = 0, pattern; pattern = ignoreFiles[i]; i++) {
-    if (minimatch(path, pattern)) {
-      return true
+    if (pattern[0] == "!") {
+      if (!minimatch(path, pattern)) {
+        // not matching a negated pattern means this path does match the underlying pattern
+        // so a previous ignore should be overridden
+        ignore = false
+      }
+    } else {
+      if (minimatch(path,pattern)) {
+        ignore = true
+      }
     }
   }
-  return false
+  return ignore
 }
 
 


### PR DESCRIPTION
The current handling of git ignore rules is incorrect for negated patterns.

```
foo*
!foobar
```

The above ignore rules should ignore `foo*` except for `foobar` and not ignore any other files. Currently the negated rule results in every other file being ignored (because every other file matches that rule according to `minimatch`).

This PR updates the ignore logic to handle negated rules correctly.